### PR TITLE
设置seekbar不能点击滑动

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "24.0.3"
     defaultConfig {
         applicationId "com.mcxtzhang.swipecaptcha"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/mcxtzhang/swipecaptcha/MainActivity.java
+++ b/app/src/main/java/com/mcxtzhang/swipecaptcha/MainActivity.java
@@ -11,18 +11,19 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
+import com.mcxtzhang.captchalib.CannotTouchSeekBar;
 import com.mcxtzhang.captchalib.SwipeCaptchaView;
 
 public class MainActivity extends AppCompatActivity {
     SwipeCaptchaView mSwipeCaptchaView;
-    SeekBar mSeekBar;
+    CannotTouchSeekBar mSeekBar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         mSwipeCaptchaView = (SwipeCaptchaView) findViewById(R.id.swipeCaptchaView);
-        mSeekBar = (SeekBar) findViewById(R.id.dragBar);
+        mSeekBar = (CannotTouchSeekBar) findViewById(R.id.dragBar);
         findViewById(R.id.btnChange).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,7 +22,7 @@
         app:captchaHeight="30dp"
         app:captchaWidth="30dp"/>
 
-    <SeekBar
+    <com.mcxtzhang.captchalib.CannotTouchSeekBar
         android:id="@+id/dragBar"
         android:layout_width="320dp"
         android:layout_height="60dp"

--- a/captchalib/build.gradle
+++ b/captchalib/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "24.0.3"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"

--- a/captchalib/src/main/java/com/mcxtzhang/captchalib/CannotTouchSeekBar.java
+++ b/captchalib/src/main/java/com/mcxtzhang/captchalib/CannotTouchSeekBar.java
@@ -1,0 +1,40 @@
+package com.mcxtzhang.captchalib;
+
+import android.content.Context;
+import android.support.v7.widget.AppCompatSeekBar;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+public class CannotTouchSeekBar extends AppCompatSeekBar {
+    private static int left = 0;
+    private static int right = 0;
+
+    public CannotTouchSeekBar(Context context) {
+       this(context,null);
+    }
+
+    public CannotTouchSeekBar(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if(left==0||right==0) {
+            left = getThumb().getBounds().left;
+            right = getThumb().getBounds().right;
+        }
+
+
+        int eventX = (int) event.getX();
+
+        if(event.getAction()==MotionEvent.ACTION_DOWN){
+            if(eventX<=left||eventX>=right){
+                return false;
+            }
+        }
+
+
+        return super.dispatchTouchEvent(event);
+    }
+}


### PR DESCRIPTION
用线上的几个实例进行对比，发现不能点击拖动，使用禁用了seekbar的点击功能。